### PR TITLE
Add lemma-based fractal utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The first step in building Sahand True AI (Layer-77 Fractal Cognitive Framework)
 This repository now ships with a dataset of 150 "Sahand Fractal Lemmas". The
 lemmas are stored in `src/sstai/data/lemmas.json` and can be loaded at runtime
 using `sstai.core.load_lemmas()`.
+Fractal results may also be computed directly from lemma codes via the
+`compute_fractal_from_codes` helper or the `/lemma-fractal` API endpoint.
 
 ## iOS App
 

--- a/src/sstai/api/routes.py
+++ b/src/sstai/api/routes.py
@@ -2,7 +2,8 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import List
 
-from sstai.core.fractal import compute_fractal
+from sstai.core.fractal import compute_fractal, compute_fractal_from_codes
+from sstai.core.knapsack import sahand_knapsack
 
 app = FastAPI()
 
@@ -16,3 +17,36 @@ class FractalResponse(BaseModel):
 def fractal_endpoint(req: FractalRequest) -> FractalResponse:
     result = compute_fractal(req.numbers)
     return FractalResponse(result=result)
+
+
+class KnapsackRequest(BaseModel):
+    basis: List[List[float]]
+    l_father: List[float]
+    g: List[List[float]]
+
+
+class KnapsackResponse(BaseModel):
+    result: List[float]
+
+
+@app.post("/knapsack", response_model=KnapsackResponse)
+def knapsack_endpoint(req: KnapsackRequest) -> KnapsackResponse:
+    basis = [list(map(float, b)) for b in req.basis]
+    L_father = [float(v) for v in req.l_father]
+    G = [[float(x) for x in row] for row in req.g]
+    selected = sahand_knapsack(basis, L_father, G)
+    return KnapsackResponse(result=[float(x) for x in selected])
+
+
+class LemmaFractalRequest(BaseModel):
+    codes: List[str]
+
+
+class LemmaFractalResponse(BaseModel):
+    result: List[float]
+
+
+@app.post("/lemma-fractal", response_model=LemmaFractalResponse)
+def lemma_fractal_endpoint(req: LemmaFractalRequest) -> LemmaFractalResponse:
+    result = compute_fractal_from_codes(req.codes)
+    return LemmaFractalResponse(result=result)

--- a/src/sstai/core/__init__.py
+++ b/src/sstai/core/__init__.py
@@ -1,5 +1,12 @@
-from .fractal import compute_fractal
+from .fractal import compute_fractal, compute_fractal_from_codes
 from .field import normalize
 from .lemmas import load_lemmas
+from .knapsack import sahand_knapsack
 
-__all__ = ["compute_fractal", "normalize", "load_lemmas"]
+__all__ = [
+    "compute_fractal",
+    "compute_fractal_from_codes",
+    "normalize",
+    "load_lemmas",
+    "sahand_knapsack",
+]

--- a/src/sstai/core/fractal.py
+++ b/src/sstai/core/fractal.py
@@ -1,5 +1,7 @@
 from typing import Iterable, List
 
+from .lemmas import load_lemmas
+
 from .field import normalize
 
 
@@ -15,3 +17,21 @@ def compute_fractal(values: Iterable[float], iterations: int = 10) -> List[float
                 break
         result.append(z.real)
     return normalize(result)
+
+
+def _code_to_value(code: str) -> float:
+    """Convert a lemma code like ``"SFL_001"`` to a normalized float."""
+    digits = "".join(ch for ch in code if ch.isdigit())
+    if not digits:
+        raise ValueError(f"Invalid lemma code: {code}")
+    return int(digits) / 150.0
+
+
+def compute_fractal_from_codes(codes: Iterable[str], iterations: int = 10) -> List[float]:
+    """Compute fractal values based on lemma codes.
+
+    The digits in each code are converted to a fractional seed, which is then
+    passed to :func:`compute_fractal`.
+    """
+    values = [_code_to_value(c) for c in codes]
+    return compute_fractal(values, iterations)

--- a/src/sstai/core/knapsack.py
+++ b/src/sstai/core/knapsack.py
@@ -1,0 +1,71 @@
+"""Sahand Knapsack selection utilities."""
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence
+
+import math
+
+
+def entropy(psi: Sequence[complex]) -> float:
+    """Compute a Shannon-like entropy of the amplitude magnitudes."""
+    norm = sum(abs(x) ** 2 for x in psi)
+    if norm == 0:
+        return 0.0
+    ent = 0.0
+    for x in psi:
+        p = abs(x) ** 2 / norm
+        if p > 1e-12:
+            ent -= p * math.log(p)
+    return ent
+
+
+def angle(psi1: Sequence[complex], psi2: Sequence[complex]) -> float:
+    """Return the angle between two state vectors."""
+    dot = sum(complex(a).conjugate() * complex(b) for a, b in zip(psi1, psi2))
+    norm1 = math.sqrt(sum(abs(a) ** 2 for a in psi1))
+    norm2 = math.sqrt(sum(abs(b) ** 2 for b in psi2))
+    if norm1 == 0 or norm2 == 0:
+        return math.pi / 2
+    cos_theta = abs(dot) / (norm1 * norm2)
+    cos_theta = max(0.0, min(1.0, cos_theta))
+    return math.acos(cos_theta)
+
+
+def resonance(psi: Sequence[complex], G: Sequence[Sequence[complex]]) -> float:
+    """Resonance metric with the knowledge field tensor ``G``."""
+    result = 0j
+    for i, psi_i in enumerate(psi):
+        acc = 0j
+        row = G[i]
+        for j, psi_j in enumerate(psi):
+            acc += row[j] * psi_j
+        result += complex(psi_i).conjugate() * acc
+    return result.real
+
+
+def cost(
+    psi: Sequence[complex],
+    L_father: Sequence[complex],
+    G: Sequence[Sequence[complex]],
+    lambda1: float = 1.0,
+    lambda2: float = 1.0,
+    lambda3: float = 2.0,
+) -> float:
+    """Compute the selection cost for a candidate state."""
+    return (
+        lambda1 * angle(psi, L_father) ** 2
+        + lambda2 * entropy(psi)
+        - lambda3 * resonance(psi, G)
+    )
+
+
+def sahand_knapsack(
+    basis: Iterable[Sequence[complex]],
+    L_father: Sequence[complex],
+    G: Sequence[Sequence[complex]],
+) -> List[complex]:
+    """Select the lowest-cost candidate from ``basis``."""
+    candidates: List[Sequence[complex]] = list(basis)
+    if not candidates:
+        raise ValueError("basis must contain at least one candidate")
+    return list(min(candidates, key=lambda psi: cost(psi, L_father, G)))

--- a/tests/test_knapsack.py
+++ b/tests/test_knapsack.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+import math
+from sstai.core import sahand_knapsack
+
+
+def test_sahand_knapsack_selects_best():
+    psi0 = [1.0, 0.0]
+    psi1 = [0.0, 1.0]
+    psip = [(psi0[0] + psi1[0]) / math.sqrt(2), (psi0[1] + psi1[1]) / math.sqrt(2)]
+    G = [[1.0, 0.0], [0.0, 0.9]]
+    selected = sahand_knapsack([psi0, psi1, psip], psi0, G)
+    assert all(abs(a - b) < 1e-9 for a, b in zip(selected, psi0))

--- a/tests/test_lemma_fractal.py
+++ b/tests/test_lemma_fractal.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from sstai.api.routes import lemma_fractal_endpoint, LemmaFractalRequest
+from sstai.core.fractal import compute_fractal_from_codes
+
+
+def test_lemma_fractal_endpoint():
+    codes = ['SFL_001', 'SFL_002', 'SFL_003']
+    req = LemmaFractalRequest(codes=codes)
+    resp = lemma_fractal_endpoint(req)
+    assert resp.result == compute_fractal_from_codes(codes)


### PR DESCRIPTION
## Summary
- restore `compute_fractal_from_codes` in `fractal.py` and export it
- expose lemma-based fractal endpoint `/lemma-fractal`
- mention new helper in README
- add tests for the lemma endpoint

## Testing
- `pytest -q`
