### PR TITLE
Add WiFi access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ First GitHub repo by Sahand Shahhosseini – starting point of Sahand True AI jo
 
 **Started by Sahand Shahhosseini on May 21, 2025**  
 The first step in building Sahand True AI (Layer-77 Fractal Cognitive Framework).
+
+## WiFi Access
+See [docs/wifi_access.md](docs/wifi_access.md) for instructions on connecting Sahand's device to a WiFi network using `nmcli` or the accompanying Python helper.

--- a/docs/wifi_access.md
+++ b/docs/wifi_access.md
@@ -1,0 +1,32 @@
+# WiFi Access Guide
+
+This guide explains how to connect Sahand's device to a WiFi network on Linux using NetworkManager's command line tool `nmcli`.
+
+## Requirements
+
+- NetworkManager installed and running.
+- Proper permissions to control network interfaces (may require `sudo`).
+
+## Steps
+
+1. List available networks:
+   ```bash
+   nmcli device wifi list
+   ```
+2. Connect to a network (replace `SSID` and `PASSWORD`):
+   ```bash
+   nmcli device wifi connect "SSID" password "PASSWORD"
+   ```
+3. Verify connection:
+   ```bash
+   nmcli connection show --active
+   ```
+
+You can also perform these steps using the helper script in `src/wifi_access.py`:
+
+```bash
+python src/wifi_access.py list --interface wlan0     # list networks
+python src/wifi_access.py connect SSID PASSWORD --interface wlan0
+```
+
+If your system does not use NetworkManager, consult your distribution's documentation for the appropriate tool (e.g., `wpa_supplicant`, `iwconfig`).

--- a/src/wifi_access.py
+++ b/src/wifi_access.py
@@ -1,0 +1,51 @@
+"""Utilities for managing WiFi connections using ``nmcli``.
+
+The helper functions are thin wrappers around ``nmcli`` so that tests can mock
+out the command execution.  They do not attempt to parse the output in detail
+but provide a minimal Python API for common tasks used throughout the docs.
+"""
+
+import subprocess
+from typing import Optional
+
+
+def list_networks(interface: Optional[str] = None) -> None:
+    """List available WiFi networks."""
+    cmd = ["nmcli", "device", "wifi", "list"]
+    if interface:
+        cmd.extend(["ifname", interface])
+    subprocess.run(cmd, check=True)
+
+
+def connect_wifi(ssid: str, password: str, interface: Optional[str] = None) -> None:
+    """Connect to a WiFi network using NetworkManager (nmcli)."""
+    cmd = ["nmcli", "device", "wifi", "connect", ssid, "password", password]
+    if interface:
+        cmd.extend(["ifname", interface])
+    subprocess.run(cmd, check=True)
+    # Display active connections so the user can verify the result
+    subprocess.run(["nmcli", "connection", "show", "--active"], check=True)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="WiFi helper using nmcli")
+    sub = parser.add_subparsers(dest="command")
+
+    list_p = sub.add_parser("list", help="List available networks")
+    list_p.add_argument("--interface", help="WiFi interface name")
+
+    conn_p = sub.add_parser("connect", help="Connect to a network")
+    conn_p.add_argument("ssid", help="WiFi network SSID")
+    conn_p.add_argument("password", help="WiFi password")
+    conn_p.add_argument("--interface", help="WiFi interface name")
+
+    args = parser.parse_args()
+
+    if args.command == "list":
+        list_networks(args.interface)
+    elif args.command == "connect":
+        connect_wifi(args.ssid, args.password, args.interface)
+    else:
+        parser.print_help()

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from wifi_access import list_networks, connect_wifi
+
+
+def test_list_networks_builds_command():
+    with patch('subprocess.run') as run_mock:
+        list_networks(interface='wlan0')
+        run_mock.assert_called_once_with(
+            ['nmcli', 'device', 'wifi', 'list', 'ifname', 'wlan0'],
+            check=True
+        )
+
+
+def test_connect_wifi_builds_commands():
+    with patch('subprocess.run') as run_mock:
+        connect_wifi('MySSID', 'pwd123', interface='wlan0')
+        run_mock.assert_any_call(
+            ['nmcli', 'device', 'wifi', 'connect', 'MySSID', 'password', 'pwd123', 'ifname', 'wlan0'],
+            check=True
+        )
+        run_mock.assert_any_call(
+            ['nmcli', 'connection', 'show', '--active'],
+            check=True
+        )
+        assert run_mock.call_count == 2
+


### PR DESCRIPTION
## Summary
- document how to connect to WiFi using `nmcli`
- update README with new WiFi doc
- provide a small Python helper to connect via NetworkManager using Python


------
https://chatgpt.com/codex/tasks/task_e_68358ed896ec832498b398d0fab2a0d9