### PR TITLE
Add PyTorch model and licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sahand Shahhosseini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,26 @@ from sstai.ai import train_fractal_model, predict_fractal
 model = train_fractal_model()
 predictions = predict_fractal(model, ["SFL_001", "SFL_002"])
 ```
+
+## Usage
+
+Run the FastAPI server with:
+
+```bash
+uvicorn sstai.api.routes:app --reload
+```
+
+Execute the test suite with:
+
+```bash
+pytest
+```
+
+Example model training script is provided under `examples/torch_train.py`.
+
+For reproducible research we track stable checkpoints in `GOLD_CHECKPOINT.yml` as explained in `docs/gold-layer.md`.
+
+## License
+
+This project is released under the terms of the MIT License. See [LICENSE](LICENSE) for details.
+

--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -3,5 +3,6 @@
 This repository hosts a simple FastAPI app with a vectorized fractal endpoint used for tests.
 It demonstrates minimal usage of FastAPI alongside numerical tools like NumPy and PyTorch.
 The fractal values are normalized so that the result forms a basic probability distribution.
-
+The code also includes a small `FractalLattice` utility. It creates a `6×13×5` grid that can
+be iterated with a toy fractal rule, representing personal Yggdrasil structures.
 

--- a/examples/torch_train.py
+++ b/examples/torch_train.py
@@ -1,0 +1,6 @@
+"""Example training script for the PyTorch fractal model."""
+
+from sstai.ai import train_torch_fractal_model, predict_torch_fractal
+
+model = train_torch_fractal_model()
+print(predict_torch_fractal(model, ["SFL_001", "SFL_002"]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Sahand Shahhosseini True AI – prototype implementation"
 authors = ["Sahand Shahhosseini <creator@example.com>"]
 readme = "README.md"
+license = "MIT"
 packages = [{ include = "sstai", from = "src" }]
 include = ["src/sstai/data/lemmas.json"]
 

--- a/src/sstai/ai/__init__.py
+++ b/src/sstai/ai/__init__.py
@@ -1,6 +1,11 @@
 """Simple machine learning utilities."""
 
 from .fractal_model import FractalModel, train_fractal_model, predict_fractal
+from .torch_fractal_model import (
+    TorchFractalModel,
+    train_torch_fractal_model,
+    predict_torch_fractal,
+)
 from .rewrite import (
     add_interaction,
     load_interactions,
@@ -9,11 +14,14 @@ from .rewrite import (
 )
 
 __all__ = [
-    'FractalModel',
-    'train_fractal_model',
-    'predict_fractal',
-    'add_interaction',
-    'load_interactions',
-    'clear_interactions',
-    'train_fractal_model_with_interactions',
+    "FractalModel",
+    "train_fractal_model",
+    "predict_fractal",
+    "TorchFractalModel",
+    "train_torch_fractal_model",
+    "predict_torch_fractal",
+    "add_interaction",
+    "load_interactions",
+    "clear_interactions",
+    "train_fractal_model_with_interactions",
 ]

--- a/src/sstai/ai/torch_fractal_model.py
+++ b/src/sstai/ai/torch_fractal_model.py
@@ -1,0 +1,64 @@
+"""PyTorch implementation of the fractal regression model."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+try:
+    import torch
+    from torch import nn
+except Exception as e:  # pragma: no cover - optional dependency
+    torch = None
+    nn = None
+
+from sstai.core.fractal import _code_to_value, compute_fractal
+from sstai.core.lemmas import load_lemmas
+
+
+class TorchFractalModel:  # pragma: no cover - simple wrapper
+    def __init__(self) -> None:
+        if torch is None:
+            raise ImportError("PyTorch is required for TorchFractalModel")
+        self.linear = nn.Linear(1, 1)
+
+    def predict(self, x: Iterable[float]) -> List[float]:
+        if torch is None:
+            raise ImportError("PyTorch is required for TorchFractalModel")
+        with torch.no_grad():
+            t = torch.tensor([[v] for v in x], dtype=torch.float32)
+            return self.linear(t).squeeze(1).tolist()
+
+
+def _load_dataset() -> tuple[list[float], list[float]]:
+    lemmas = load_lemmas()
+    codes = [lemma["code"] for lemma in lemmas]
+    xs = [_code_to_value(c) for c in codes]
+    ys = compute_fractal(xs)
+    return xs, ys
+
+
+def train_torch_fractal_model(epochs: int = 200, lr: float = 0.1) -> TorchFractalModel:
+    if torch is None:
+        raise ImportError("PyTorch is required for training")
+    x, y = _load_dataset()
+    model = TorchFractalModel()
+    optim = torch.optim.SGD(model.linear.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+    t_x = torch.tensor([[v] for v in x], dtype=torch.float32)
+    t_y = torch.tensor([[v] for v in y], dtype=torch.float32)
+    for _ in range(epochs):
+        optim.zero_grad()
+        pred = model.linear(t_x)
+        loss = loss_fn(pred, t_y)
+        loss.backward()
+        optim.step()
+    return model
+
+
+def predict_torch_fractal(
+    model: TorchFractalModel, codes: Iterable[str]
+) -> List[float]:
+    if torch is None:
+        raise ImportError("PyTorch is required for prediction")
+    x = [_code_to_value(c) for c in codes]
+    return model.predict(x)

--- a/tests/test_torch_model.py
+++ b/tests/test_torch_model.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+pytest.importorskip("torch")
+
+from sstai.ai import train_torch_fractal_model, predict_torch_fractal
+
+
+def test_torch_model_training():
+    model = train_torch_fractal_model(epochs=10, lr=0.1)
+    preds = predict_torch_fractal(model, ["SFL_001"])
+    assert len(preds) == 1
+    assert isinstance(preds[0], float)


### PR DESCRIPTION
## Summary
- add MIT license
- describe how to run the server, tests and training in README
- mention GOLD_CHECKPOINT file usage
- merge overview text about FractalLattice utility
- provide PyTorch implementation of fractal model and expose via API
- add example training script and tests
- set project license in pyproject

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0d05b57c8324a971e20cf5f591dd