### PR TITLE
Add SahandKnapsack module integrated with placeholder SAT solver

### DIFF
--- a/src/sstai/core/sahand_knapsack.py
+++ b/src/sstai/core/sahand_knapsack.py
@@ -1,0 +1,23 @@
+from .sahand_sat import SahandSAT
+
+
+class SahandKnapsack:
+    def __init__(self, problem_json):
+        self.problem_json = problem_json
+        self.sat_solver = SahandSAT()
+        self.sat_solver.load_from_json(problem_json)
+
+    def analyze_and_optimize(self, verbose=False):
+        self.sat_solver.print_summary()
+        solution = self.sat_solver.solve(verbose=verbose)
+        self.solution = solution
+        return {
+            "selected_variables": [
+                v for v, val in solution["assignment"].items() if val
+            ],
+            "total_weight": solution["min_weight"],
+            "time": solution["time_seconds"],
+        }
+
+    def export_analysis(self, filepath):
+        self.sat_solver.export_to_json(filepath, include_solution=True)

--- a/src/sstai/core/sahand_sat.py
+++ b/src/sstai/core/sahand_sat.py
@@ -1,0 +1,46 @@
+class SahandSAT:
+    """Placeholder SAT solver used for testing SahandKnapsack."""
+
+    def __init__(self):
+        self.problem = None
+
+    def load_from_json(self, problem_json):
+        self.problem = problem_json
+
+    def print_summary(self):
+        if self.problem is None:
+            print("No problem loaded")
+        else:
+            vars_count = len(self.problem.get("variables", []))
+            print(f"Loaded problem with {vars_count} variables")
+
+    def solve(self, verbose=False):
+        if self.problem is None:
+            raise ValueError("No problem loaded")
+        variables = self.problem.get("variables", [])
+        assignment = {v: False for v in variables}
+        if variables:
+            assignment[variables[0]] = True
+        total_weight = sum(
+            self.problem.get("weights", {}).get(v, 0)
+            for v, selected in assignment.items()
+            if selected
+        )
+        solution = {
+            "assignment": assignment,
+            "min_weight": total_weight,
+            "time_seconds": 0.0,
+        }
+        self.solution = solution
+        return solution
+
+    def export_to_json(self, filepath, include_solution=False):
+        import json
+
+        data = {
+            "problem": self.problem,
+        }
+        if include_solution:
+            data["solution"] = getattr(self, "solution", None)
+        with open(filepath, "w") as f:
+            json.dump(data, f)

--- a/tests/test_sahand_knapsack_integration.py
+++ b/tests/test_sahand_knapsack_integration.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from sstai.core.sahand_knapsack import SahandKnapsack
+
+
+def test_sahand_knapsack_integration():
+    problem = {
+        "variables": ["x1", "x2"],
+        "weights": {"x1": 1, "x2": 2},
+        "clauses": [[1], [2]],
+    }
+    knapsack = SahandKnapsack(problem)
+    result = knapsack.analyze_and_optimize()
+    assert result["selected_variables"] == ["x1"]
+    assert result["total_weight"] == 1
+    assert "time" in result


### PR DESCRIPTION
## Summary
- add a minimal `SahandSAT` placeholder solver
- add `SahandKnapsack` class that uses `SahandSAT`
- test integration of the new knapsack module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b43b7f7f08324bb225cad8bb6dfe4