### PR TITLE
Improve SahandSAT solver

### DIFF
--- a/src/sstai/core/sahand_sat.py
+++ b/src/sstai/core/sahand_sat.py
@@ -1,46 +1,110 @@
+import itertools
+import json
+import time
+from typing import Dict, Iterable, List, Union
+
+
 class SahandSAT:
-    """Placeholder SAT solver used for testing SahandKnapsack."""
+    """Simple CNF SAT solver with weight-based optimization."""
 
-    def __init__(self):
-        self.problem = None
+    def __init__(
+        self,
+        clauses: Iterable[Iterable[int]] | None = None,
+        weights: Dict[int, float] | None = None,
+    ):
+        self.clauses: List[List[int]] = [list(c) for c in clauses] if clauses else []
+        self.weights: Dict[int, float] = weights or {}
+        self.variables = sorted({abs(l) for c in self.clauses for l in c})
+        self.solution: Dict[str, Union[float, dict]] | None = None
 
-    def load_from_json(self, problem_json):
-        self.problem = problem_json
+    def load_from_json(self, data: Union[str, Dict]) -> None:
+        """Load clauses and weights from a JSON filepath or object."""
+        if isinstance(data, str):
+            with open(data, "r") as f:
+                data = json.load(f)
+        self.clauses = [list(cl) for cl in data.get("clauses", [])]
+        self.weights = {int(k): float(v) for k, v in data.get("weights", {}).items()}
+        self.variables = sorted({abs(l) for c in self.clauses for l in c})
 
-    def print_summary(self):
-        if self.problem is None:
-            print("No problem loaded")
-        else:
-            vars_count = len(self.problem.get("variables", []))
-            print(f"Loaded problem with {vars_count} variables")
+    def is_satisfied(self, assignment: Dict[int, bool]) -> bool:
+        """Return True if all clauses are satisfied under the assignment."""
+        for clause in self.clauses:
+            if not any(
+                (lit > 0 and assignment.get(abs(lit), False))
+                or (lit < 0 and not assignment.get(abs(lit), False))
+                for lit in clause
+            ):
+                return False
+        return True
 
-    def solve(self, verbose=False):
-        if self.problem is None:
-            raise ValueError("No problem loaded")
-        variables = self.problem.get("variables", [])
-        assignment = {v: False for v in variables}
-        if variables:
-            assignment[variables[0]] = True
-        total_weight = sum(
-            self.problem.get("weights", {}).get(v, 0)
-            for v, selected in assignment.items()
-            if selected
+    def total_weight(self, assignment: Dict[int, bool]) -> float:
+        """Compute the sum of weights for variables set to True."""
+        return sum(
+            self.weights.get(v, 0.0) for v in self.variables if assignment.get(v, False)
         )
-        solution = {
-            "assignment": assignment,
-            "min_weight": total_weight,
-            "time_seconds": 0.0,
-        }
-        self.solution = solution
-        return solution
 
-    def export_to_json(self, filepath, include_solution=False):
-        import json
+    def solve(self, verbose: bool = False) -> Dict:
+        """Brute-force search for the minimal-weight satisfying assignment."""
+        min_weight = float("inf")
+        best_assignment: Dict[int, bool] | None = None
+        start = time.time()
+        total = 2 ** len(self.variables)
 
-        data = {
-            "problem": self.problem,
+        for idx, bits in enumerate(
+            itertools.product([False, True], repeat=len(self.variables))
+        ):
+            assignment = {v: bits[i] for i, v in enumerate(self.variables)}
+            if self.is_satisfied(assignment):
+                w = self.total_weight(assignment)
+                if w < min_weight:
+                    min_weight = w
+                    best_assignment = assignment.copy()
+            if verbose and idx % 100 == 0:
+                print(f"Checked {idx}/{total} assignments...")
+
+        elapsed = time.time() - start
+        self.solution = {
+            "min_weight": min_weight,
+            "assignment": best_assignment,
+            "vars": self.variables,
+            "clause_count": len(self.clauses),
+            "time_seconds": elapsed,
         }
+        return self.solution
+
+    def export_to_json(self, filepath: str, include_solution: bool = False) -> None:
+        """Write problem definition and optional solution to a JSON file."""
+        data = {"clauses": self.clauses, "weights": self.weights}
         if include_solution:
-            data["solution"] = getattr(self, "solution", None)
+            if self.solution is None:
+                self.solve()
+            data.update(
+                {
+                    "solution": self.solution["assignment"],
+                    "min_weight": self.solution["min_weight"],
+                }
+            )
         with open(filepath, "w") as f:
-            json.dump(data, f)
+            json.dump(data, f, indent=2)
+
+    def symbolic_signature(self) -> Dict[str, float]:
+        """Return a symbolic summary of the SAT instance."""
+        literal_count = sum(len(c) for c in self.clauses)
+        var_count = len(self.variables)
+        entropy_sum = sum(self.weights.values())
+        return {
+            "literal_count": literal_count,
+            "variable_count": var_count,
+            "entropy_weight_sum": entropy_sum,
+            "clauses": len(self.clauses),
+            "density": len(self.clauses) / max(1, var_count),
+        }
+
+    def print_summary(self) -> None:
+        sig = self.symbolic_signature()
+        print("\U0001f4d8 SahandSAT Instance Summary")
+        print(f" - Variables: {sig['variable_count']}")
+        print(f" - Clauses: {sig['clauses']}")
+        print(f" - Total Entropy Weight: {sig['entropy_weight_sum']:.3f}")
+        print(f" - Density: {sig['density']:.2f}")
+        print(f" - Literals (total): {sig['literal_count']}")

--- a/tests/test_sahand_knapsack_integration.py
+++ b/tests/test_sahand_knapsack_integration.py
@@ -8,12 +8,12 @@ from sstai.core.sahand_knapsack import SahandKnapsack
 
 def test_sahand_knapsack_integration():
     problem = {
-        "variables": ["x1", "x2"],
-        "weights": {"x1": 1, "x2": 2},
-        "clauses": [[1], [2]],
+        "variables": [1, 2],
+        "weights": {1: 1, 2: 2},
+        "clauses": [[1], [1, 2]],
     }
     knapsack = SahandKnapsack(problem)
     result = knapsack.analyze_and_optimize()
-    assert result["selected_variables"] == ["x1"]
+    assert result["selected_variables"] == [1]
     assert result["total_weight"] == 1
     assert "time" in result

--- a/tests/test_sahand_sat.py
+++ b/tests/test_sahand_sat.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from sstai.core.sahand_sat import SahandSAT
+
+
+def test_sahand_sat_solver_min_weight():
+    clauses = [[1, 2], [-1, 2]]
+    weights = {1: 1.0, 2: 0.5}
+    solver = SahandSAT(clauses=clauses, weights=weights)
+    result = solver.solve()
+    assert result["min_weight"] == 0.5
+    assert result["assignment"][2] is True
+    assert result["assignment"][1] is False


### PR DESCRIPTION
## Summary
- implement an extended `SahandSAT` solver with JSON loading, full brute-force solving and reporting
- adjust integration test for updated solver semantics
- add a dedicated unit test for `SahandSAT`

## Testing
- `black -q src/sstai/core/sahand_sat.py tests/test_sahand_knapsack_integration.py tests/test_sahand_sat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b465b96c083249fb27ced70d62100