### PR TITLE
Add optional OpenAI chat dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,14 @@ The FastAPI backend exposes this model at the `/fractal-net` endpoint.
 
 ## Chat CLI
 
-Create a `.env` file in `examples/` with your `OPENAI_API_KEY`. Then run:
+Create a `.env` file in `examples/` with your `OPENAI_API_KEY`. Install the
+optional dependencies and run:
+
+```bash
+pip install "openai>=1.21.1" "python-dotenv>=1.0.1" "rich>=13.7.1"
+```
+
+Then start the chat loop with:
 
 ```bash
 python examples/chat_cli.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ fastapi = "^0.111"
 uvicorn = {extras = ["standard"], version = "^0.29"}
 pydantic = "^2.7"
 sqlmodel = "^0.0.16"
+openai = ">=1.21.1"
+python-dotenv = ">=1.0.1"
+rich = ">=13.7.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2"

--- a/sstai/requirements.txt
+++ b/sstai/requirements.txt
@@ -4,3 +4,6 @@ pydantic==2.7.0
 sqlmodel==0.0.16
 numpy==1.26.0
 torch==2.2.0
+openai>=1.21.1
+python-dotenv>=1.0.1
+rich>=13.7.1


### PR DESCRIPTION
## Summary
- add openai, python-dotenv and rich to the project dependencies
- document installation of these packages in the Chat CLI section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b4c8c4b1483249493c2cbc7f994e0