### PR TITLE
Add optional PySAT backend to SahandSAT

### DIFF
--- a/tests/test_sahand_sat.py
+++ b/tests/test_sahand_sat.py
@@ -14,3 +14,10 @@ def test_sahand_sat_solver_min_weight():
     assert result["min_weight"] == 0.5
     assert result["assignment"][2] is True
     assert result["assignment"][1] is False
+
+
+def test_sahand_sat_solver_method():
+    clauses = [[1], [-1, 2]]
+    solver = SahandSAT(clauses=clauses)
+    result = solver.solve()
+    assert result["method"] in {"bruteforce", "pysat"}


### PR DESCRIPTION
## Summary
- extend `SahandSAT` with optional PySAT backend
- ensure solution export records solving method
- test solver method detection

## Testing
- `black src/sstai/core/sahand_sat.py tests/test_sahand_sat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bb844b8248324bd03b8483a78920f