### PR TITLE
Add OpenAI env example for CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ __pycache__/
 *.pyd
 !.env
 .env.*
+!.env.example
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The FastAPI backend exposes this model at the `/fractal-net` endpoint.
 
 ## Chat CLI
 
-Create a `.env` file in `examples/` with your `OPENAI_API_KEY`. Install the
-optional dependencies and run:
+Copy `.env.example` to `.env` in the `examples/` directory and add your
+`OPENAI_API_KEY`. Install the optional dependencies and run:
 
 ```bash
 pip install "openai>=1.21.1" "python-dotenv>=1.0.1" "rich>=13.7.1"

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your-openai-key
+#OPENAI_ORG_ID=your-org-id
+MODEL_NAME=gpt-4o-mini


### PR DESCRIPTION
## Summary
- provide `examples/.env.example` with the `OPENAI_API_KEY` placeholder
- mention copying the example env file in README
- allow the example env file in `.gitignore`
- restore newline at end of `interactions.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c340e1208832494b27af00bc5c766