### PR TITLE
Add additional SAT solver components

### DIFF
--- a/sat_solver/SahandKnapsack.py
+++ b/sat_solver/SahandKnapsack.py
@@ -1,0 +1,30 @@
+"""Knapsack-style optimization using the Sahand SAT solver."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+from .SahandSAT_Extended import SahandSATExtended
+
+
+class SahandKnapsack:
+    def __init__(self, problem: str | Dict) -> None:
+        if isinstance(problem, str):
+            with open(problem, "r") as f:
+                problem = json.load(f)
+        weights = {int(k): float(v) for k, v in problem.get("weights", {}).items()}
+        self.solver = SahandSATExtended(
+            clauses=problem.get("clauses"),
+            weights=weights,
+        )
+
+    def optimize(self, verbose: bool = False) -> Dict:
+        return self.solver.solve(verbose)
+
+    def export(self, path: str) -> None:
+        if not hasattr(self.solver, "solution"):
+            result = self.optimize()
+        else:
+            result = self.solver.solution
+        self.solver.save_json(path, result)

--- a/sat_solver/SahandSAT_Core.py
+++ b/sat_solver/SahandSAT_Core.py
@@ -1,0 +1,48 @@
+"""Core utilities for the Sahand SAT solver."""
+
+from __future__ import annotations
+
+import itertools
+from typing import Dict, Iterable, List
+
+
+class SahandSATCore:
+    """Basic SAT solver with brute-force search."""
+
+    def __init__(
+        self,
+        clauses: Iterable[Iterable[int]] | None = None,
+        weights: Dict[int, float] | None = None,
+    ) -> None:
+        self.clauses: List[List[int]] = [list(c) for c in clauses] if clauses else []
+        self.weights: Dict[int, float] = weights or {}
+        self.variables = sorted({abs(l) for c in self.clauses for l in c})
+
+    # ----- helpers -----
+    def is_satisfied(self, assignment: Dict[int, bool]) -> bool:
+        return all(
+            any(
+                (lit > 0 and assignment.get(abs(lit), False))
+                or (lit < 0 and not assignment.get(abs(lit), False))
+                for lit in clause
+            )
+            for clause in self.clauses
+        )
+
+    def cost(self, assignment: Dict[int, bool]) -> float:
+        return sum(
+            self.weights.get(v, 0.0) for v in self.variables if assignment.get(v, False)
+        )
+
+    # ----- solving -----
+    def solve_bruteforce(self, verbose: bool = False) -> Dict:
+        best, best_a = float("inf"), None
+        for i, bits in enumerate(itertools.product([0, 1], repeat=len(self.variables))):
+            assignment = {v: bool(bits[j]) for j, v in enumerate(self.variables)}
+            if self.is_satisfied(assignment):
+                c = self.cost(assignment)
+                if c < best:
+                    best, best_a = c, assignment.copy()
+            if verbose and i % 1000 == 0:
+                print(f"BF checked {i}")
+        return {"assignment": best_a, "min_weight": best}

--- a/sat_solver/SahandSAT_Extended.py
+++ b/sat_solver/SahandSAT_Extended.py
@@ -1,0 +1,65 @@
+"""Extended SAT solver with optional PySAT backend and JSON utilities."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Dict, Iterable, List
+
+from .SahandSAT_Core import SahandSATCore
+
+try:  # pragma: no cover - optional dependency
+    from pysat.formula import CNF
+    from pysat.solvers import Glucose3
+
+    HAS_PYSAT = True
+except Exception:  # pragma: no cover - PySAT may be missing
+    HAS_PYSAT = False
+
+
+class SahandSATExtended(SahandSATCore):
+    """Sahand SAT solver with convenient IO and PySAT acceleration."""
+
+    def load_json(self, path_or_obj: str | Dict) -> None:
+        if isinstance(path_or_obj, str):
+            with open(path_or_obj, "r") as f:
+                data = json.load(f)
+        else:
+            data = path_or_obj
+        self.clauses = [list(c) for c in data.get("clauses", [])]
+        self.weights = {int(k): float(v) for k, v in data.get("weights", {}).items()}
+        self.variables = sorted({abs(l) for c in self.clauses for l in c})
+
+    def save_json(self, path: str, solution: Dict | None = None) -> None:
+        data = {"clauses": self.clauses, "weights": self.weights}
+        if solution:
+            data["solution"] = solution
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
+    def solve(self, verbose: bool = False) -> Dict:
+        if HAS_PYSAT:
+            return self._solve_pysat(verbose)
+        return self.solve_bruteforce(verbose)
+
+    def _solve_pysat(self, verbose: bool = False) -> Dict:
+        start = time.time()
+        cnf = CNF(from_clauses=self.clauses)
+        best, best_a = float("inf"), None
+        with Glucose3(bootstrap_with=cnf) as solver:
+            while solver.solve():
+                model = solver.get_model()
+                a = {abs(v): v > 0 for v in model}
+                c = self.cost(a)
+                if c < best:
+                    best, best_a = c, a.copy()
+                solver.add_clause([-v if a[abs(v)] else v for v in self.variables])
+        return {
+            "assignment": best_a,
+            "min_weight": best,
+            "method": "pysat",
+            "time": time.time() - start,
+        }
+
+    def summary(self) -> Dict[str, int]:
+        return {"variables": len(self.variables), "clauses": len(self.clauses)}

--- a/sat_solver/sahandsat_stabilized.json
+++ b/sat_solver/sahandsat_stabilized.json
@@ -1,0 +1,6 @@
+{
+  "lemmas": [
+    {"id": "L1", "clauses": [[1, 2]], "solution": {"1": false, "2": true}},
+    {"id": "L2", "clauses": [[-1, 2], [3]], "solution": {"1": false, "2": true, "3": true}}
+  ]
+}

--- a/tests/test_sahand_knapsack.py
+++ b/tests/test_sahand_knapsack.py
@@ -1,0 +1,10 @@
+from sat_solver.SahandKnapsack import SahandKnapsack
+
+
+def test_knapsack_optimize():
+    problem = {"clauses": [[1, 2], [-1, 2]], "weights": {"1": 1.0, "2": 0.5}}
+    knapsack = SahandKnapsack(problem)
+    result = knapsack.optimize()
+    assert result["min_weight"] == 0.5
+    assert result["assignment"][2] is True
+    assert result["assignment"][1] is False

--- a/tests/test_sahand_sat_core.py
+++ b/tests/test_sahand_sat_core.py
@@ -1,0 +1,11 @@
+from sat_solver.SahandSAT_Core import SahandSATCore
+
+
+def test_core_bruteforce():
+    clauses = [[1, 2], [-1, 2]]
+    weights = {1: 1.0, 2: 0.5}
+    solver = SahandSATCore(clauses=clauses, weights=weights)
+    result = solver.solve_bruteforce()
+    assert result["min_weight"] == 0.5
+    assert result["assignment"][2] is True
+    assert result["assignment"][1] is False


### PR DESCRIPTION
## Summary
- add new minimal solver `SahandSAT_Core` with brute force search
- extend solver with PySAT integration and JSON utilities in `SahandSAT_Extended`
- provide a simple knapsack optimizer interface
- include example solved lemma dataset
- test new solver modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c379797cc8324afaca0dd3d98aa49