### PR TITLE
Fix SAT solver test import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 !.env.example
 .idea/
 .vscode/
+src/sstai/data/lemmas.db

--- a/sat_solver/__init__.py
+++ b/sat_solver/__init__.py
@@ -1,0 +1,1 @@
+# Package for Sahand SAT solver modules

--- a/tests/test_sat_solver_pysat.py
+++ b/tests/test_sat_solver_pysat.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from sat_solver.SahandSAT_PySAT import SahandSAT
 
 


### PR DESCRIPTION
## Summary
- add `__init__.py` so `sat_solver` is treated as a package
- patch SAT solver test to ensure the local package is on `sys.path`
- ignore the generated `lemmas.db` file

## Testing
- `pytest -q`
- `pytest tests/test_sat_solver_pysat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_683c38643ad88324ae65fc03a45c83f2