### PR TITLE
Add WiFi access docs and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ First GitHub repo by Sahand Shahhosseini – starting point of Sahand True AI jo
 **Started by Sahand Shahhosseini on May 21, 2025**  
 The first step in building Sahand True AI (Layer-77 Fractal Cognitive Framework).
 
+## WiFi Access
+
+See [docs/wifi_access.md](docs/wifi_access.md) for instructions on connecting
+Sahand's device to a WiFi network using `nmcli` or the accompanying Python
+helper.
+
 ## Sahand Fractal Lemmas
 
 This repository now ships with a dataset of 150 "Sahand Fractal Lemmas". The

--- a/docs/wifi_access.md
+++ b/docs/wifi_access.md
@@ -1,0 +1,24 @@
+# WiFi Access
+
+This project includes utilities for connecting Sahand's device to a WiFi network. The easiest method uses the `nmcli` command-line tool. The same logic is also available via a small Python helper for scripted use.
+
+## Connecting with nmcli
+
+1. List available networks:
+   ```bash
+   nmcli device wifi list
+   ```
+2. Connect to a network:
+   ```bash
+   nmcli device wifi connect <SSID> password <PASSWORD>
+   ```
+
+## Python Helper
+
+A convenience function wrapping `nmcli` is provided in `scripts/wifi_helper.py`. Run it with your network credentials:
+
+```bash
+python scripts/wifi_helper.py --ssid <SSID> --password <PASSWORD>
+```
+
+This script simply calls `nmcli` under the hood, so it requires NetworkManager to be installed and active on the target machine.

--- a/scripts/wifi_helper.py
+++ b/scripts/wifi_helper.py
@@ -1,0 +1,29 @@
+"""Simple wrapper around `nmcli` for connecting to WiFi."""
+
+import subprocess
+import argparse
+
+
+def connect_wifi(ssid: str, password: str) -> None:
+    """Connect to a WiFi network using nmcli."""
+    subprocess.run([
+        "nmcli",
+        "device",
+        "wifi",
+        "connect",
+        ssid,
+        "password",
+        password,
+    ], check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Connect to WiFi using nmcli")
+    parser.add_argument("--ssid", required=True, help="WiFi SSID")
+    parser.add_argument("--password", required=True, help="WiFi password")
+    args = parser.parse_args()
+    connect_wifi(args.ssid, args.password)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_wifi_helper.py
+++ b/tests/test_wifi_helper.py
@@ -1,0 +1,31 @@
+import subprocess
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import wifi_helper
+
+
+def test_connect_wifi_runs_nmcli(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append((cmd, check))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    wifi_helper.connect_wifi("MySSID", "secret")
+    assert calls == [
+        (
+            [
+                "nmcli",
+                "device",
+                "wifi",
+                "connect",
+                "MySSID",
+                "password",
+                "secret",
+            ],
+            True,
+        )
+    ]


### PR DESCRIPTION
## Summary
- document how to connect to WiFi
- add `wifi_helper.py` helper script
- reference WiFi access docs from README
- test WiFi helper logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c41158ce483248ae026fa7e360fe3